### PR TITLE
Sleep No More

### DIFF
--- a/code/__DEFINES/stat.dm
+++ b/code/__DEFINES/stat.dm
@@ -1,7 +1,8 @@
 //mob/var/stat things
-#define CONSCIOUS	0
-#define UNCONSCIOUS	1
-#define DEAD		2
+#define CONSCIOUS		0
+#define UNCONSCIOUS		1
+#define DEAD			2
+#define ANESTHETIZED	3
 
 // TGUI flags
 #define STATUS_INTERACTIVE 2 // GREEN Visability

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -525,6 +525,8 @@ GLOBAL_LIST_INIT(do_after_once_tracker, list())
 				status = "<font color='orange'><b>Unconscious</b></font>"
 			if(DEAD)
 				status = "<font color='red'><b>Dead</b></font>"
+			if(ANESTHETIZED)
+				status = "<font color='blue'<b>Anesthetized</b></font>"
 		health_description = "Status = [status]"
 		health_description += "<BR>Oxy: [L.getOxyLoss()] - Tox: [L.getToxLoss()] - Fire: [L.getFireLoss()] - Brute: [L.getBruteLoss()] - Clone: [L.getCloneLoss()] - Brain: [L.getBrainLoss()]"
 	else

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -301,9 +301,7 @@
 	switch(stat)
 		if(CONSCIOUS)
 			holder.icon_state = "hudstat"
-		if(UNCONSCIOUS)
-			holder.icon_state = "hudoffline"
-		if(ANESTHEIZED)
+		if(UNCONSCIOUS,ANESTHETIZED)
 			holder.icon_state = "hudoffline"
 		else
 			holder.icon_state = "huddead2"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -303,6 +303,8 @@
 			holder.icon_state = "hudstat"
 		if(UNCONSCIOUS)
 			holder.icon_state = "hudoffline"
+		if(ANESTHEIZED)
+			holder.icon_state = "hudoffline"
 		else
 			holder.icon_state = "huddead2"
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -303,7 +303,7 @@
 			holder.icon_state = "hudstat"
 		if(UNCONSCIOUS,ANESTHETIZED)
 			holder.icon_state = "hudoffline"
-		else
+		if(DEAD)
 			holder.icon_state = "huddead2"
 
 //Borgie battery tracking!

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -375,7 +375,7 @@
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
 					continue //Dead
 				if(L.stat == ANESTHETIZED)
-					msg += "<b>[L.name</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
+					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -374,6 +374,8 @@
 				if(L.stat == DEAD)
 					msg += "<b>[L.name]</b> ([L.ckey]), the [L.job] (Dead)\n"
 					continue //Dead
+				if(L.stat == ANESTHETIZED)
+					msg += "<b>[L.name</b> ([L.ckey]), the [L.job] (Anesthetized)\n"
 
 			continue //Happy connected client
 		for(var/mob/dead/observer/D in GLOB.mob_list)

--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -388,11 +388,11 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/paper/abductor/AltClick()
 	return
 
-#define BATON_STUN 0
-#define BATON_SLEEP 1
-#define BATON_CUFF 2
-#define BATON_PROBE 3
-#define BATON_MODES 4
+#define BATON_STUN        0
+#define BATON_ANESTHESIA  1
+#define BATON_CUFF        2
+#define BATON_PROBE       3
+#define BATON_MODES       4
 
 /obj/item/abductor_baton
 	name = "advanced baton"
@@ -413,7 +413,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch(mode)
 		if(BATON_STUN)
 			txt = "stunning"
-		if(BATON_SLEEP)
+		if(BATON_ANESTHESIA)
 			txt = "sleep inducement"
 		if(BATON_CUFF)
 			txt = "restraining"
@@ -431,7 +431,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		if(BATON_STUN)
 			icon_state = "wonderprodStun"
 			item_state = "wonderprodStun"
-		if(BATON_SLEEP)
+		if(BATON_ANESTHESIA)
 			icon_state = "wonderprodSleep"
 			item_state = "wonderprodSleep"
 		if(BATON_CUFF)
@@ -442,20 +442,15 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			item_state = "wonderprodProbe"
 
 /obj/item/abductor_baton/attack(mob/target, mob/living/user)
-	if(!isabductor(user))
+	if(!isabductor(user))	//Non-Abdcutors cannot use this
 		return
-
-	if(isrobot(target))
+	if(isrobot(target))		//You can't stun a Robot
 		..()
 		return
-
-	if(!isliving(target))
+	if(!isliving(target))	//Yeah, they have to be living
 		return
-
 	var/mob/living/L = target
-
 	user.do_attack_animation(L)
-
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
@@ -465,8 +460,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch(mode)
 		if(BATON_STUN)
 			StunAttack(L,user)
-		if(BATON_SLEEP)
-			SleepAttack(L,user)
+		if(BATON_ANESTHESIA)
+			AnesthetizeAttack(L,user)
 		if(BATON_CUFF)
 			CuffAttack(L,user)
 		if(BATON_PROBE)
@@ -497,17 +492,17 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 	add_attack_logs(user, L, "Stunned with [src]")
 
-/obj/item/abductor_baton/proc/SleepAttack(mob/living/L,mob/living/user)
+/obj/item/abductor_baton/proc/AnesthetizeAttack(mob/living/L,mob/living/user)
 	if(L.stunned || L.sleeping)
-		L.visible_message("<span class='danger'>[user] has induced sleep in [L] with [src]!</span>", \
+		L.visible_message("<span class='danger'>[user] has infused anesthesia into [L] with [src]!</span>", \
 							"<span class='userdanger'>You suddenly feel very drowsy!</span>")
 		playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
-		L.Sleeping(60)
-		add_attack_logs(user, L, "Put to sleep with [src]")
+		L.Sleeping(60, TRUE, FALSE, TRUE)	//amount=60,updating=TRUE,no_alert=FALSE,ane=TRUE
+		add_attack_logs(user, L, "Anesthetized with [src]")
 	else
-		L.AdjustDrowsy(1)
-		to_chat(user, "<span class='warning'>Sleep inducement works fully only on stunned specimens! </span>")
-		L.visible_message("<span class='danger'>[user] tried to induce sleep in [L] with [src]!</span>", \
+		L.AdjustDrowsy(1, TRUE)				//Anesthetize
+		to_chat(user, "<span class='warning'>Anesthesia infusement works fully only on stunned specimens! </span>")
+		L.visible_message("<span class='danger'>[user] tried to infuse anesthesia into [L] with [src]!</span>", \
 							"<span class='userdanger'>You suddenly feel drowsy!</span>")
 
 /obj/item/abductor_baton/proc/CuffAttack(mob/living/L,mob/living/user)
@@ -571,7 +566,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	switch(mode)
 		if(BATON_STUN)
 			. += "<span class='warning'>The baton is in stun mode.</span>"
-		if(BATON_SLEEP)
+		if(BATON_ANESTHESIA)
 			. += "<span class='warning'>The baton is in sleep inducement mode.</span>"
 		if(BATON_CUFF)
 			. += "<span class='warning'>The baton is in restraining mode.</span>"

--- a/code/game/gamemodes/vampire/vampire.dm
+++ b/code/game/gamemodes/vampire/vampire.dm
@@ -297,7 +297,7 @@ You are weak to holy things and starlight. Don't go into space and avoid the Cha
 			return
 		old_bloodtotal = bloodtotal
 		old_bloodusable = bloodusable
-		if(H.stat < DEAD)
+		if(H.stat != DEAD)
 			if(H.ckey || H.player_ghosted) //Requires ckey regardless if monkey or humanoid, or the body has been ghosted before it died
 				blood = min(20, H.blood_volume)	// if they have less than 20 blood, give them the remnant else they get 20 blood
 				bloodtotal += blood / 2	//divide by 2 to counted the double suction since removing cloneloss -Melandor0

--- a/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/code/game/gamemodes/vampire/vampire_powers.dm
@@ -29,7 +29,7 @@
 
 	var/fullpower = vampire.get_ability(/datum/vampire_passive/full)
 
-	if(user.stat >= DEAD)
+	if(user.stat == DEAD)
 		to_chat(user, "<span class='warning'>Not when you're dead!</span>")
 		return 0
 
@@ -58,7 +58,7 @@
 
 	var/fullpower = vampire.get_ability(/datum/vampire_passive/full)
 
-	if(user.stat >= DEAD)
+	if(user.stat == DEAD)
 		return 0
 
 	if(vampire.nullified && !fullpower)

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -191,6 +191,8 @@
 		patientStatus = "Awake"
 	else if(table.patient.stat == UNCONSCIOUS)
 		patientStatus = "Asleep"
+	else if(table.patient.stat == ANESTHETIZED)
+		patientStatus = "Anesthetized"
 
 	if(isNewPatient)
 		atom_say("New patient detected, loading stats")

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -106,7 +106,7 @@
 	if(output)
 		var/temp = ""
 		if(patient)
-			temp = "<br />\[Occupant: [patient] ([patient.stat > 1 ? "*DECEASED*" : "Health: [patient.health]%"])\]<br /><a href='?src=[UID()];view_stats=1'>View stats</a>|<a href='?src=[UID()];eject=1'>Eject</a>"
+			temp = "<br />\[Occupant: [patient] ([patient.stat == DEAD ? "*DECEASED*" : "Health: [patient.health]%"])\]<br /><a href='?src=[UID()];view_stats=1'>View stats</a>|<a href='?src=[UID()];eject=1'>Eject</a>"
 		return "[output] [temp]"
 	return
 
@@ -155,15 +155,17 @@
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/proc/get_patient_dam()
 	var/t1
 	switch(patient.stat)
-		if(0)
+		if(CONSCIOUS)
 			t1 = "Conscious"
-		if(1)
+		if(UNCONSCIOUS)
 			t1 = "Unconscious"
-		if(2)
+		if(DEAD)
 			t1 = "*dead*"
+		if(ANESTHETIZED)
+			t1 = "Anesthetized"
 		else
 			t1 = "Unknown"
-	return {"<font color="[patient.health > 50 ? "blue" : "red"]"><b>Health:</b> [patient.stat > 1 ? "[t1]" : "[patient.health]% ([t1])"]</font><br />
+	return {"<font color="[patient.health > 50 ? "blue" : "red"]"><b>Health:</b> [patient.stat == DEAD ? "[t1]" : "[patient.health]% ([t1])"]</font><br />
 				<font color="[patient.bodytemperature > 50 ? "blue" : "red"]"><b>Core Temperature:</b> [patient.bodytemperature-T0C]&deg;C ([patient.bodytemperature*1.8-459.67]&deg;F)</font><br />
 				<font color="[patient.getBruteLoss() < 60 ? "blue" : "red"]"><b>Brute Damage:</b> [patient.getBruteLoss()]%</font><br />
 				<font color="[patient.getOxyLoss() < 60 ? "blue" : "red"]"><b>Respiratory Damage:</b> [patient.getOxyLoss()]%</font><br />

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -250,7 +250,7 @@
 		return
 	if(href_list["close"])
 		return
-	if(usr.stat > 0)
+	if(usr.stat != CONSCIOUS)
 		return
 	var/datum/topic_input/afilter = new /datum/topic_input(href,href_list)
 	if(href_list["select_equip"])

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -696,6 +696,8 @@ REAGENT SCANNER
 			t1 = "Conscious"
 		if(UNCONSCIOUS)
 			t1 = "Unconscious"
+		if(ANESTHETIZED)
+			t1 = "Anesthetized"
 		else
 			t1 = "*dead*"
 	dat += "[target.health > 50 ? "<font color='blue'>" : "<font color='red'>"]\tHealth %: [target.health], ([t1])</font><br>"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -134,7 +134,7 @@ REAGENT SCANNER
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		to_chat(user, "<span class='notice'>Analyzing Results for [H]:\n\t Overall Status: dead</span>")
 	else
-		to_chat(user, "<span class='notice'>Analyzing Results for [H]:\n\t Overall Status: [H.stat > 1 ? "dead" : "[H.health]% healthy"]</span>")
+		to_chat(user, "<span class='notice'>Analyzing Results for [H]:\n\t Overall Status: [H.stat == DEAD ? "dead" : "[H.health]% healthy"]</span>")
 	to_chat(user, "\t Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font>")
 	to_chat(user, "\t Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
 	to_chat(user, "<span class='notice'>Body Temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span>")

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -20,6 +20,8 @@
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)
 					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
+				if(ANESTHETIZED)
+					entry += " - <font color='darkgray'><b>Anesthetized</b></font>"
 				if(DEAD)
 					if(isobserver(C.mob))
 						var/mob/dead/observer/O = C.mob

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -49,7 +49,7 @@
 /mob/living/carbon/proc/experience_dream(dream_image, isNightmare)
 	dreaming--
 	nightmare--
-	if(stat != UNCONSCIOUS || InCritical())
+	if(stat != (UNCONSCIOUS || ANESTHETIZED)|| InCritical())
 		return
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -49,7 +49,7 @@
 /mob/living/carbon/proc/experience_dream(dream_image, isNightmare)
 	dreaming--
 	nightmare--
-	if(stat != (UNCONSCIOUS | ANESTHETIZED)|| InCritical())
+	if(stat != (UNCONSCIOUS | ANESTHETIZED) || InCritical())
 		return
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -49,7 +49,7 @@
 /mob/living/carbon/proc/experience_dream(dream_image, isNightmare)
 	dreaming--
 	nightmare--
-	if(stat != (UNCONSCIOUS || ANESTHETIZED)|| InCritical())
+	if(stat != (UNCONSCIOUS | ANESTHETIZED)|| InCritical())
 		return
 	if(isNightmare)
 		dream_image = "<span class='cultitalic'>[dream_image]</span>"

--- a/code/modules/mining/lavaland/loot/colossus_loot.dm
+++ b/code/modules/mining/lavaland/loot/colossus_loot.dm
@@ -292,7 +292,7 @@
 	. = ..()
 	if(isliving(target) && target != src)
 		var/mob/living/L = target
-		if(L.stat < DEAD)
+		if(L.stat != DEAD)
 			L.heal_overall_damage(heal_power, heal_power)
 			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -70,7 +70,7 @@
 			italics = TRUE
 			sound_vol *= 0.5
 
-	if(sleeping || stat == UNCONSCIOUS)
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return 0
 
@@ -118,7 +118,7 @@
 	if(!client)
 		return
 
-	if(sleeping || stat == UNCONSCIOUS) //If unconscious or sleeping
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED)) //If unconscious or sleeping
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 
@@ -182,7 +182,7 @@
 	to_chat(src, heard)
 
 /mob/proc/hear_holopad_talk(list/message_pieces, verb = "says", mob/speaker = null, obj/effect/overlay/holo_pad_hologram/H)
-	if(sleeping || stat == UNCONSCIOUS)
+	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -70,7 +70,7 @@
 			italics = TRUE
 			sound_vol *= 0.5
 
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return 0
 
@@ -118,7 +118,7 @@
 	if(!client)
 		return
 
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED)) //If unconscious or sleeping
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED)) //If unconscious or sleeping
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 
@@ -182,7 +182,7 @@
 	to_chat(src, heard)
 
 /mob/proc/hear_holopad_talk(list/message_pieces, verb = "says", mob/speaker = null, obj/effect/overlay/holo_pad_hologram/H)
-	if(sleeping || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(sleeping || stat == (UNCONSCIOUS | ANESTHETIZED))
 		hear_sleep(multilingual_to_message(message_pieces))
 		return
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -57,11 +57,10 @@
 /obj/item/clothing/mask/facehugger/examine(mob/user)
 	. = ..()
 	if(real)//So that giant red text about probisci doesn't show up for fake ones
-		switch(stat)
-			if(DEAD,UNCONSCIOUS,ANESTHETIZED)
-				. += "<span class='boldannounce'>[src] is not moving.</span>"
-			if(CONSCIOUS)
-				. += "<span class='boldannounce'>[src] seems to be active!</span>"
+		if(stat == CONSCIOUS)
+			. += "<span class='boldannounce'>[src] seems to be active!</span>"
+		else
+			. += "<span class='boldannounce'>[src] is not moving.</span>"
 		if(sterile)
 			. += "<span class='boldannounce'>It looks like the proboscis has been removed.</span>"
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -58,7 +58,7 @@
 	. = ..()
 	if(real)//So that giant red text about probisci doesn't show up for fake ones
 		switch(stat)
-			if(DEAD,UNCONSCIOUS)
+			if(DEAD,UNCONSCIOUS,ANESTHETIZED)
 				. += "<span class='boldannounce'>[src] is not moving.</span>"
 			if(CONSCIOUS)
 				. += "<span class='boldannounce'>[src] seems to be active!</span>"
@@ -197,7 +197,7 @@
 	icon_state = "[initial(icon_state)]"
 
 /obj/item/clothing/mask/facehugger/proc/GoIdle()
-	if(stat == DEAD || stat == UNCONSCIOUS)
+	if(stat != CONSCIOUS)
 		return
 
 	stat = UNCONSCIOUS

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -221,7 +221,7 @@
 				M.visible_message("<span class='notice'>[M] shakes [src], but [p_they()] [p_do()] not respond. Probably suffering from SSD.", \
 				"<span class='notice'>You shake [src], but [p_theyre()] unresponsive. Probably suffering from SSD.</span>")
 			if(lying) // /vg/: For hugs. This is how update_icon figgers it out, anyway.  - N3X15
-				add_attack_logs(M, src, "Shaked", ATKLOG_ALL)
+				add_attack_logs(M, src, "Shaken", ATKLOG_ALL)
 				if(ishuman(src))
 					var/mob/living/carbon/human/H = src
 					if(H.w_uniform)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -320,7 +320,7 @@
 	msg += "</span>"
 
 	if(!appears_dead)
-		if(stat == UNCONSCIOUS)
+		if(stat == (UNCONSCIOUS || ANESTHETIZED))
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -320,7 +320,7 @@
 	msg += "</span>"
 
 	if(!appears_dead)
-		if(stat == (UNCONSCIOUS || ANESTHETIZED))
+		if(stat == (UNCONSCIOUS | ANESTHETIZED))
 			msg += "[p_they(TRUE)] [p_are()]n't responding to anything around [p_them()] and seems to be asleep.\n"
 		else if(getBrainLoss() >= 60)
 			msg += "[p_they(TRUE)] [p_have()] a stupid expression on [p_their()] face.\n"

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -18,14 +18,14 @@
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0)
+/mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -18,14 +18,14 @@
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
+/mob/living/carbon/human/SetParalysis(amount, updating = TRUE, force = 0, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else
 		amount = dna.species.spec_stun(src,amount)
 	return ..()
 
-/mob/living/carbon/human/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
+/mob/living/carbon/human/SetSleeping(amount, updating = TRUE, no_alert = FALSE, ane = FALSE)
 	if(dna.species.stun_mod)
 		amount = amount * dna.species.stun_mod
 	else

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -322,9 +322,9 @@
 
 		AdjustHallucinate(-2)
 
-	// Keep SSD people asleep
+	// Keep SSD people Anesthetized
 	if(player_logged)
-		Sleeping(2)
+		Sleeping(2, TRUE)
 
 /mob/living/carbon/handle_sleeping()
 	if(..())

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -384,7 +384,7 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
-	if(stat == (UNCONSCIOUS || ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
+	if(stat == (UNCONSCIOUS | ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
 			switch(health)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -300,10 +300,13 @@
 		AdjustDizzy(-restingpwr)
 
 	if(drowsyness)
-		AdjustDrowsy(-restingpwr)
+		var/ane = FALSE
+		if(anesthetized)
+			ane = TRUE
+		AdjustDrowsy(-restingpwr, ane)
 		EyeBlurry(2)
 		if(prob(5))
-			AdjustSleeping(1)
+			AdjustSleeping(1, 0, INFINITY, 1, FALSE, ane)
 			Paralyse(5)
 
 	if(confused)
@@ -381,7 +384,7 @@
 /mob/living/carbon/update_damage_hud()
 	if(!client)
 		return
-	if(stat == UNCONSCIOUS && health <= HEALTH_THRESHOLD_CRIT)
+	if(stat == (UNCONSCIOUS || ANESTHETIZED) && health <= HEALTH_THRESHOLD_CRIT)
 		if(check_death_method())
 			var/severity = 0
 			switch(health)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -176,7 +176,7 @@
 		if(SA_partialpressure > SA_para_min)
 			Paralyse(3)
 			if(SA_partialpressure > SA_sleep_min)
-				AdjustSleeping(2, bound_lower = 0, bound_upper = 10)
+				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //Amount=2, bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
 		else if(SA_partialpressure > 0.01)
 			if(prob(20))
 				emote(pick("giggle","laugh"))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -174,9 +174,9 @@
 	//TRACE GASES
 	if(breath.sleeping_agent)
 		if(SA_partialpressure > SA_para_min)
-			Paralyse(3)
+			Paralyse(3, TRUE, 0, TRUE)						//amount=3,updating=TRUE,force=0,ane=TRUE
 			if(SA_partialpressure > SA_sleep_min)
-				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //Amount=2, bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
+				AdjustSleeping(2, 0, 10, TRUE, FALSE, TRUE) //amount=2,bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
 		else if(SA_partialpressure > 0.01)
 			if(prob(20))
 				emote(pick("giggle","laugh"))

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -11,7 +11,7 @@
 				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == (UNCONSCIOUS || ANESTHETIZED))
+			if(stat == (UNCONSCIOUS | ANESTHETIZED))
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	update_damage_hud()

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -6,7 +6,7 @@
 			death()
 			create_debug_log("died of damage, trigger reason: [reason]")
 			return
-		if(paralysis || sleeping || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
+		if(sleeping || paralysis || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
 			if(stat == CONSCIOUS)
 				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")

--- a/code/modules/mob/living/carbon/update_status.dm
+++ b/code/modules/mob/living/carbon/update_status.dm
@@ -8,10 +8,10 @@
 			return
 		if(paralysis || sleeping || (check_death_method() && getOxyLoss() > 50) || (status_flags & FAKEDEATH) || health <= HEALTH_THRESHOLD_CRIT && check_death_method())
 			if(stat == CONSCIOUS)
-				KnockOut()
+				KnockOut(TRUE, anesthetized)
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == UNCONSCIOUS)
+			if(stat == (UNCONSCIOUS || ANESTHETIZED))
 				WakeUp()
 				create_debug_log("woke up, trigger reason: [reason]")
 	update_damage_hud()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1082,7 +1082,7 @@
 			if((stat == DEAD) && (var_value < DEAD))//Bringing the dead back to life
 				GLOB.dead_mob_list -= src
 				GLOB.alive_mob_list += src
-			if((stat < DEAD) && (var_value == DEAD))//Kill he
+			if((stat != DEAD) && (var_value == DEAD))//Kill he
 				GLOB.alive_mob_list -= src
 				GLOB.dead_mob_list += src
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -277,8 +277,7 @@
 
 
 /mob/living/proc/InCritical()
-	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS)
-
+	return (health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD && stat == UNCONSCIOUS) //Does this need ANESTHETIZED? Please Review
 
 /mob/living/ex_act(severity)
 	..()
@@ -497,7 +496,7 @@
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()
-	else if(stat == UNCONSCIOUS)
+	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
 		WakeUp()
 
 	update_fire()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -496,7 +496,7 @@
 	surgeries.Cut() //End all surgeries.
 	if(stat == DEAD)
 		update_revive()
-	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+	else if(stat == (UNCONSCIOUS | ANESTHETIZED))
 		WakeUp()
 
 	update_fire()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -443,7 +443,7 @@
 		if(CONSCIOUS)
 			if(!client)
 				msg += "\nIt appears to be in stand-by mode." //afk
-		if(UNCONSCIOUS)
+		if(UNCONSCIOUS, ANESTHETIZED)	// Sanity
 			msg += "\n<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)
 			msg += "\n<span class='deadsay'>It looks completely unsalvageable.</span>"

--- a/code/modules/mob/living/silicon/pai/software/pai_apps.dm
+++ b/code/modules/mob/living/silicon/pai/software/pai_apps.dm
@@ -379,7 +379,7 @@
 
 	if(isliving(held))
 		data["holder"] = held.name
-		data["dead"] = (held.stat > UNCONSCIOUS)
+		data["dead"] = (held.stat == DEAD)
 		data["health"] = held.health
 		data["brute"] = held.getBruteLoss()
 		data["oxy"] = held.getOxyLoss()

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -258,7 +258,7 @@
 		if("robot")
 			var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
 			var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
-			to_chat(user, "<span class='notice'>Analyzing Results for [M]:\n\t Overall Status: [M.stat > 1 ? "fully disabled" : "[M.health]% functional"]</span>")
+			to_chat(user, "<span class='notice'>Analyzing Results for [M]:\n\t Overall Status: [M.stat == DEAD ? "fully disabled" : "[M.health]% functional"]</span>")
 			to_chat(user, "\t Key: <font color='#FFA500'>Electronics</font>/<font color='red'>Brute</font>")
 			to_chat(user, "\t Damage Specifics: <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font>")
 			if(M.timeofdeath && M.stat == DEAD)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -38,7 +38,7 @@
 		if(CONSCIOUS)
 			if(!client)
 				msg += "It appears to be in stand-by mode.\n" //afk
-		if(UNCONSCIOUS)
+		if(UNCONSCIOUS, ANESTHETIZED)
 			msg += "<span class='warning'>It doesn't seem to be responding.</span>\n"
 		if(DEAD)
 			if(!suiciding)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -57,7 +57,7 @@
 	if(stat != CONSCIOUS)
 		uneq_all()
 
-	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS || ANESTHETIZED))
+	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS | ANESTHETIZED))
 		radio.on = 0
 	else
 		radio.on = 1

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -57,7 +57,7 @@
 	if(stat != CONSCIOUS)
 		uneq_all()
 
-	if(!is_component_functioning("radio") || stat == UNCONSCIOUS)
+	if(!is_component_functioning("radio") || stat == (UNCONSCIOUS || ANESTHETIZED))
 		radio.on = 0
 	else
 		radio.on = 1

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -20,7 +20,7 @@
 				update_headlamp()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == UNCONSCIOUS)
+			if(stat == (UNCONSCIOUS || ANESTHETIZED))
 				WakeUp()
 				update_headlamp()
 				create_debug_log("woke up, trigger reason: [reason]")

--- a/code/modules/mob/living/silicon/robot/update_status.dm
+++ b/code/modules/mob/living/silicon/robot/update_status.dm
@@ -20,7 +20,7 @@
 				update_headlamp()
 				create_debug_log("fell unconscious, trigger reason: [reason]")
 		else
-			if(stat == (UNCONSCIOUS || ANESTHETIZED))
+			if(stat == (UNCONSCIOUS | ANESTHETIZED)) //Look, I don't know how a robot became ANESTHETIZED - what you do in your own time is your own business!
 				WakeUp()
 				update_headlamp()
 				create_debug_log("woke up, trigger reason: [reason]")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -201,7 +201,10 @@
 			if(robust_searching)
 				if(faction_check && !attack_same)
 					return FALSE
-				if(L.stat > stat_attack)
+				var/lstat = L.stat
+				if(lstat == ANESTHETIZED)
+					lstat = UNCONSCIOUS
+				if(lstat > stat_attack)
 					return FALSE
 				if(L in friends)
 					return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining/gutlunch.dm
@@ -73,7 +73,10 @@
 
 		if(faction_check_mob(L) && !attack_same)
 			return FALSE
-		if(L.stat > stat_attack || L.stat != stat_attack && stat_exclusive)
+		var/lstat = L.stat
+		if(lstat == ANESTHETIZED)
+			lstat = UNCONSCIOUS
+		if(lstat > stat_attack || lstat != stat_attack && stat_exclusive)
 			return FALSE
 
 		return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -73,7 +73,10 @@
 
 		if (!faction_check_mob(L) && attack_same == 2)
 			return FALSE
-		if(L.stat > stat_attack)
+		var/lstat = L.stat
+		if(lstat == ANESTHETIZED)
+			lstat = UNCONSCIOUS
+		if(lstat > stat_attack)
 			return FALSE
 
 		return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ai.dm
+++ b/code/modules/mob/living/simple_animal/hostile/terror_spiders/terror_ai.dm
@@ -79,7 +79,7 @@
 /mob/living/simple_animal/hostile/poison/terror_spider/LoseTarget()
 	if(target && isliving(target))
 		var/mob/living/T = target
-		if(T.stat > 0)
+		if(T.stat != CONSCIOUS)
 			killcount++
 			regen_points += regen_points_per_kill
 	attackstep = 0

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -1,28 +1,33 @@
 // There, now `stat` is a proper state-machine
 
-/mob/living/proc/KnockOut(updating = 1)
+/mob/living/proc/KnockOut(updating = TRUE, anesthetized = FALSE)
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("KnockOut called on a dead mob."), src)
-		return 0
-	else if(stat == UNCONSCIOUS)
-		return 0
+		return FALSE
+	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+		return FALSE
 	create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
 	log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
-	stat = UNCONSCIOUS
+
+	if(anesthetized)
+		stat = ANESTHETIZED
+	else
+		stat = UNCONSCIOUS
+
 	if(updating)
 		update_sight()
 		update_blind_effects()
 		update_canmove()
 		set_typing_indicator(FALSE)
-	return 1
+	return TRUE
 
 /mob/living/proc/WakeUp(updating = 1)
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("WakeUp called on a dead mob."), src)
-		return 0
+		return FALSE
 	else if(stat == CONSCIOUS)
-		return 0
+		return FALSE
 	create_attack_log("<font color='red'>Woken up at [atom_loc_line(get_turf(src))]</font>")
 	add_attack_logs(src, null, "Woken up", ATKLOG_ALL)
 	log_game("[key_name(src)] woke up at [atom_loc_line(get_turf(src))]")
@@ -31,7 +36,7 @@
 		update_sight()
 		update_blind_effects()
 		update_canmove()
-	return 1
+	return TRUE
 
 /mob/living/proc/can_be_revived()
 	. = TRUE

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -6,20 +6,24 @@
 		return FALSE
 	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
 		return FALSE
-	create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
-	add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
-	log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
 
 	if(anesthetized)
 		stat = ANESTHETIZED
+		create_attack_log("<font color='red'>Anesthetized at [atom_loc_line(get_turf(src))]</font>")
+		add_attack_logs(src, null, "Anesthetized", ATKLOG_ALL)
+		log_game("[key_name(src)] was anesthetized at [atom_loc_line(get_turf(src))]")
 	else
 		stat = UNCONSCIOUS
+		create_attack_log("<font color='red'>Fallen unconscious at [atom_loc_line(get_turf(src))]</font>")
+		add_attack_logs(src, null, "Fallen unconscious", ATKLOG_ALL)
+		log_game("[key_name(src)] fell unconscious at [atom_loc_line(get_turf(src))]")
 
 	if(updating)
 		update_sight()
 		update_blind_effects()
 		update_canmove()
 		set_typing_indicator(FALSE)
+
 	return TRUE
 
 /mob/living/proc/WakeUp(updating = 1)

--- a/code/modules/mob/living/stat_states.dm
+++ b/code/modules/mob/living/stat_states.dm
@@ -4,9 +4,8 @@
 	if(stat == DEAD)
 		log_runtime(EXCEPTION("KnockOut called on a dead mob."), src)
 		return FALSE
-	else if(stat == (UNCONSCIOUS || ANESTHETIZED))
+	else if(stat == (UNCONSCIOUS | ANESTHETIZED))
 		return FALSE
-
 	if(anesthetized)
 		stat = ANESTHETIZED
 		create_attack_log("<font color='red'>Anesthetized at [atom_loc_line(get_turf(src))]</font>")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -298,6 +298,7 @@
 	return SetParalysis(max(paralysis, amount), updating, force, ane)
 
 /mob/living/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
+	anesthetized = ane
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!paralysis)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
@@ -305,7 +306,6 @@
 	if(status_flags & CANPARALYSE || force)
 		paralysis = max(amount, 0)
 		if(updating)
-			anesthetized = ane
 			update_canmove()
 			update_stat("paralysis")
 
@@ -333,13 +333,13 @@
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
+	anesthetized = ane
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!sleeping)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
 		. = STATUS_UPDATE_NONE
 	sleeping = max(amount, 0)
 	if(updating)
-		anesthetized = ane
 		update_sleeping_effects(no_alert)
 		update_canmove()
 		update_stat("sleeping")

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -124,6 +124,7 @@
 	var/stunned = 0
 	var/stuttering = 0
 	var/weakened = 0
+	var/anesthetized = FALSE
 
 // RESTING
 
@@ -170,15 +171,16 @@
 
 // DROWSY
 
-/mob/living/Drowsy(amount)
-	SetDrowsy(max(drowsyness, amount))
+/mob/living/Drowsy(amount, ane = FALSE)
+	SetDrowsy(max(drowsyness, amount), ane)
 
-/mob/living/SetDrowsy(amount)
+/mob/living/SetDrowsy(amount, ane = FALSE)
 	drowsyness = max(amount, 0)
+	anesthetized = ane
 
-/mob/living/AdjustDrowsy(amount, bound_lower = 0, bound_upper = INFINITY)
+/mob/living/AdjustDrowsy(amount, bound_lower = 0, bound_upper = INFINITY, ane = FALSE)
 	var/new_value = directional_bounded_sum(drowsyness, amount, bound_lower, bound_upper)
-	SetDrowsy(new_value)
+	SetDrowsy(new_value, ane)
 
 // DRUNK
 
@@ -324,10 +326,10 @@
 
 // SLEEPING
 
-/mob/living/Sleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/Sleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	return SetSleeping(max(sleeping, amount), updating, no_alert)
 
-/mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE)
+/mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
 	. = STATUS_UPDATE_STAT
@@ -336,13 +338,15 @@
 		. = STATUS_UPDATE_NONE
 	sleeping = max(amount, 0)
 	if(updating)
+		anesthetized = ane
 		update_sleeping_effects(no_alert)
-		update_stat("sleeping")
 		update_canmove()
+		update_stat("sleeping")
 
-/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE)
+
+/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE, ane = FALSE)
 	var/new_value = directional_bounded_sum(sleeping, amount, bound_lower, bound_upper)
-	return SetSleeping(new_value, updating, no_alert)
+	return SetSleeping(new_value, updating, no_alert, ane)
 
 // SLOWED
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -343,7 +343,6 @@
 		update_canmove()
 		update_stat("sleeping")
 
-
 /mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE, ane = FALSE)
 	var/new_value = directional_bounded_sum(sleeping, amount, bound_lower, bound_upper)
 	return SetSleeping(new_value, updating, no_alert, ane)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -294,10 +294,10 @@
 
 // PARALYSE
 
-/mob/living/Paralyse(amount, updating = 1, force = 0, ane = FALSE)
+/mob/living/Paralyse(amount, updating = TRUE, force = 0, ane = FALSE)
 	return SetParalysis(max(paralysis, amount), updating, force, ane)
 
-/mob/living/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
+/mob/living/SetParalysis(amount, updating = TRUE, force = 0, ane = FALSE)
 	anesthetized = ane
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!paralysis)) // We're not changing from + to 0 or vice versa
@@ -309,7 +309,7 @@
 			update_canmove()
 			update_stat("paralysis")
 
-/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, force = 0, ane = FALSE)
+/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = TRUE, force = 0, ane = FALSE)
 	var/new_value = directional_bounded_sum(paralysis, amount, bound_lower, bound_upper)
 	return SetParalysis(new_value, updating, force, ane)
 
@@ -327,10 +327,10 @@
 
 // SLEEPING
 
-/mob/living/Sleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
+/mob/living/Sleeping(amount, updating = TRUE, no_alert = FALSE, ane = FALSE)
 	return SetSleeping(max(sleeping, amount), updating, no_alert, ane)
 
-/mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
+/mob/living/SetSleeping(amount, updating = TRUE, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable
 		return
 	anesthetized = ane
@@ -344,7 +344,7 @@
 		update_canmove()
 		update_stat("sleeping")
 
-/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, no_alert = FALSE, ane = FALSE)
+/mob/living/AdjustSleeping(amount, bound_lower = 0, bound_upper = INFINITY, updating = TRUE, no_alert = FALSE, ane = FALSE)
 	var/new_value = directional_bounded_sum(sleeping, amount, bound_lower, bound_upper)
 	return SetSleeping(new_value, updating, no_alert, ane)
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -294,10 +294,10 @@
 
 // PARALYSE
 
-/mob/living/Paralyse(amount, updating = 1, force = 0)
-	return SetParalysis(max(paralysis, amount), updating, force)
+/mob/living/Paralyse(amount, updating = 1, force = 0, ane = FALSE)
+	return SetParalysis(max(paralysis, amount), updating, force, ane)
 
-/mob/living/SetParalysis(amount, updating = 1, force = 0)
+/mob/living/SetParalysis(amount, updating = 1, force = 0, ane = FALSE)
 	. = STATUS_UPDATE_STAT
 	if((!!amount) == (!!paralysis)) // We're not changing from + to 0 or vice versa
 		updating = FALSE
@@ -305,12 +305,13 @@
 	if(status_flags & CANPARALYSE || force)
 		paralysis = max(amount, 0)
 		if(updating)
+			anesthetized = ane
 			update_canmove()
 			update_stat("paralysis")
 
-/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, force = 0)
+/mob/living/AdjustParalysis(amount, bound_lower = 0, bound_upper = INFINITY, updating = 1, force = 0, ane = FALSE)
 	var/new_value = directional_bounded_sum(paralysis, amount, bound_lower, bound_upper)
-	return SetParalysis(new_value, updating, force)
+	return SetParalysis(new_value, updating, force, ane)
 
 // SILENT
 
@@ -327,7 +328,7 @@
 // SLEEPING
 
 /mob/living/Sleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
-	return SetSleeping(max(sleeping, amount), updating, no_alert)
+	return SetSleeping(max(sleeping, amount), updating, no_alert, ane)
 
 /mob/living/SetSleeping(amount, updating = 1, no_alert = FALSE, ane = FALSE)
 	if(frozen) // If the mob has been admin frozen, sleeping should not be changeable

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -123,6 +123,8 @@
 			SetParalysis(paralysis)
 		if("sleeping")
 			SetSleeping(sleeping)
+		if("anesthetized")
+			SetSleeping(anesthetized)
 		if("eye_blind")
 			SetEyeBlind(eye_blind)
 		if("eye_blurry")

--- a/code/modules/mob/living/update_status.dm
+++ b/code/modules/mob/living/update_status.dm
@@ -123,8 +123,6 @@
 			SetParalysis(paralysis)
 		if("sleeping")
 			SetSleeping(sleeping)
-		if("anesthetized")
-			SetSleeping(anesthetized)
 		if("eye_blind")
 			SetEyeBlind(eye_blind)
 		if("eye_blurry")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@
 				if(type & 1 && !has_vision(information_only=TRUE))
 					return
 	// Added voice muffling for Issue 41.
-	if(stat == (UNCONSCIOUS || ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
+	if(stat == (UNCONSCIOUS | ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
 		to_chat(src, "<I>... You can almost hear someone talking ...</I>")
 	else
 		to_chat(src, msg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -89,7 +89,7 @@
 				if(type & 1 && !has_vision(information_only=TRUE))
 					return
 	// Added voice muffling for Issue 41.
-	if(stat == UNCONSCIOUS || (sleeping > 0 && stat != DEAD))
+	if(stat == (UNCONSCIOUS || ANESTHETIZED) || (sleeping > 0 && stat != DEAD))
 		to_chat(src, "<I>... You can almost hear someone talking ...</I>")
 	else
 		to_chat(src, msg)

--- a/code/modules/ninja/suit/SpiderOS.dm
+++ b/code/modules/ninja/suit/SpiderOS.dm
@@ -50,7 +50,7 @@
 			if(U.dna)
 				dat += "<b>Fingerprints</b>: <i>[md5(U.dna.uni_identity)]</i><br>"
 				dat += "<b>Unique identity</b>: <i>[U.dna.unique_enzymes]</i><br>"
-			dat += "<h4>Overall Status: [U.stat > 1 ? "dead" : "[U.health]% healthy"]</h4>"
+			dat += "<h4>Overall Status: [U.stat == DEAD ? "dead" : "[U.health]% healthy"]</h4>"
 			dat += "<h4>Nutrition Status: [U.nutrition]</h4>"
 			dat += "Oxygen loss: [U.getOxyLoss()]"
 			dat += " | Toxin levels: [U.getToxLoss()]<br>"

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -34,7 +34,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L && L.stat != UNCONSCIOUS) // Awake or dead people can see their messages
+		if(L && L.stat != (UNCONSCIOUS || ANESTHETIZED)) // Awake or dead people can see their messages
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 

--- a/code/modules/pda/app.dm
+++ b/code/modules/pda/app.dm
@@ -34,7 +34,7 @@
 		else
 			L = get(pda, /mob/living/silicon)
 
-		if(L && L.stat != (UNCONSCIOUS || ANESTHETIZED)) // Awake or dead people can see their messages
+		if(L && L.stat != (UNCONSCIOUS | ANESTHETIZED)) // Awake or dead people can see their messages
 			to_chat(L, "[bicon(pda)] [message]")
 			SStgui.update_user_uis(L, pda) // Update the receiving user's PDA UI so that they can see the new message
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -124,8 +124,7 @@
 /obj/item/projectile/bullet/sniper/soporific/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && istype(target, /mob/living))
 		var/mob/living/L = target
-		L.SetSleeping(20)
-
+		L.SetSleeping(20, TRUE, FALSE, TRUE) //Anesthetize
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -15,7 +15,7 @@
 
 /datum/reagent/medicine/hydrocodone
 	name = "Hydrocodone"
-	id = "hydrocodone"
+	id = "hydrocodone"		//Pain Modification (0.99) found in helpers.dm.
 	description = "An extremely effective painkiller; may have long term abuse consequences."
 	reagent_state = LIQUID
 	color = "#C805DC"
@@ -590,7 +590,7 @@
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
-	id = "morphine"
+	id = "morphine"		//Pain Modification (0.99) found in helpers.dm.
 	description = "A strong but highly addictive opiate painkiller with sedative side effects."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
@@ -609,10 +609,10 @@
 			if(prob(7))
 				M.emote("yawn")
 		if(16 to 35)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//This will Anesthetize a patient as well as provide pain-killing (see pain.dm).
 		if(36 to INFINITY)
-			update_flags |= M.Paralyse(15, FALSE)
-			M.Drowsy(20)
+			update_flags |= M.Paralyse(15, FALSE, 0, TRUE)
+			M.Drowsy(20, TRUE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/oculine
@@ -1040,7 +1040,7 @@
 		if(31 to 40)
 			M.Drowsy(20, TRUE)
 		if(41 to INFINITY)
-			update_flags |= M.Paralyse(15, FALSE)
+			update_flags |= M.Paralyse(15, FALSE, 0, TRUE)
 			M.Drowsy(20, TRUE)
 	return ..() | update_flags
 

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -1038,10 +1038,10 @@
 			if(prob(7))
 				M.emote("yawn")
 		if(31 to 40)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)
 		if(41 to INFINITY)
 			update_flags |= M.Paralyse(15, FALSE)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)
 	return ..() | update_flags
 
 /datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -831,7 +831,7 @@
 			M.emote("faint")
 			update_flags |= M.Weaken(5, FALSE)
 		if(11 to INFINITY)
-			update_flags |= M.Paralyse(25, FALSE)
+			update_flags |= M.Paralyse(25, FALSE, 0, TRUE)	//Anethesize
 	return ..() | update_flags
 
 /datum/reagent/sulfonal

--- a/code/modules/reagents/chemistry/reagents/toxins.dm
+++ b/code/modules/reagents/chemistry/reagents/toxins.dm
@@ -630,14 +630,14 @@
 			M.AdjustDizzy(1)
 			M.Confused(10)
 		if(9 to 12)
-			M.Drowsy(10)
+			M.Drowsy(10, TRUE)	//Anesthetize
 			M.AdjustDizzy(1)
 			M.Confused(20)
 		if(13)
 			M.emote("faint")
 		if(14 to INFINITY)
 			update_flags |= M.Paralyse(10, FALSE)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//Anesthetize
 
 	M.AdjustJitter(-30)
 	if(M.getBrainLoss() <= 80)
@@ -794,7 +794,7 @@
 			M.emote("drool")
 			M.Confused(5)
 		if(2 to 4)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//Anesthetize me, Cap'n!
 		if(5)
 			M.emote("faint")
 			update_flags |= M.Weaken(5, FALSE)
@@ -851,14 +851,14 @@
 			if(prob(7))
 				M.emote("yawn")
 		if(11 to 20)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//Anesthetize
 		if(21)
 			M.emote("faint")
 		if(22 to INFINITY)
 			if(prob(20))
 				M.emote("faint")
 				update_flags |= M.Paralyse(5, FALSE)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//Anesthetize
 	update_flags |= M.adjustToxLoss(1, FALSE)
 	return ..() | update_flags
 
@@ -943,7 +943,7 @@
 				M.emote(pick("drool", "pale", "gasp"))
 		if(11 to INFINITY)
 			update_flags |= M.Stun(30, FALSE)
-			M.Drowsy(20)
+			M.Drowsy(20, TRUE)	//Anesthetize
 			if(prob(20))
 				M.emote(pick("drool", "faint", "pale", "gasp", "collapse"))
 			else if(prob(8))
@@ -1106,7 +1106,7 @@
 		if(1 to 5)
 			update_flags |= M.AdjustEyeBlurry(10, FALSE)
 		if(6 to 10)
-			M.Drowsy(10)
+			M.Drowsy(10, TRUE)	//Anesthetize
 		if(11)
 			fakedeath(M)
 		if(61 to 69)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -111,7 +111,7 @@
 
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS, 2=DEAD, 3=ANESTHETIZED. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat == (DEAD | ANESTHETIZED)) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS, 2=DEAD, 3=ANESTHETIZED. Operating on dead people is easy, too. Just sleeping won't work, though.
 		return 1
 	if(NO_PAIN in M.dna.species.species_traits)//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -111,7 +111,7 @@
 
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS, 2=DEAD, 3=ANESTHETIZED. Operating on dead people is easy, too. Just sleeping won't work, though.
 		return 1
 	if(NO_PAIN in M.dna.species.species_traits)//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -172,7 +172,7 @@
 	..()
 	if(crit_fail)
 		return
-	if(owner.stat == UNCONSCIOUS && cooldown == FALSE)
+	if(owner.stat == (UNCONSCIOUS || ANESTHETIZED) && cooldown == FALSE)
 		owner.AdjustSleeping(-100, FALSE)
 		owner.AdjustParalysis(-100, FALSE)
 		to_chat(owner, "<span class='notice'>You feel a rush of energy course through your body!</span>")

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -172,7 +172,7 @@
 	..()
 	if(crit_fail)
 		return
-	if(owner.stat == (UNCONSCIOUS || ANESTHETIZED) && cooldown == FALSE)
+	if(owner.stat == (UNCONSCIOUS | ANESTHETIZED) && cooldown == FALSE)
 		owner.AdjustSleeping(-100, FALSE)
 		owner.AdjustParalysis(-100, FALSE)
 		to_chat(owner, "<span class='notice'>You feel a rush of energy course through your body!</span>")

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -235,12 +235,12 @@
 
 	//-- TRACES --//
 
-	if(breath.sleeping_agent)	// If there's some other shit in the air lets deal with it here.
+	if(breath.sleeping_agent)				// If there's some other shit in the air lets deal with it here.
 		if(SA_pp > SA_para_min)
-			H.Paralyse(3) // 3 gives them one second to wake up and run away a bit!
-			if(SA_pp > SA_sleep_min) // Enough to make us sleep as well
-				H.AdjustSleeping(8, bound_lower = 0, bound_upper = 10)
-		else if(SA_pp > 0.01)	// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
+			H.Paralyse(3, TRUE, 0, TRUE)	// 3 gives them one second to wake up and run away a bit!
+			if(SA_pp > SA_sleep_min)		// Enough to make us sleep as well
+				H.AdjustSleeping(8, 0, 10, TRUE, FALSE, TRUE)	//amount=8,bound_lower=0,bound_upper=10,updating=TRUE,no_alert=FALSE,ane=TRUE
+		else if(SA_pp > 0.01)				// There is sleeping gas in their lungs, but only a little, so give them a bit of a warning
 			if(prob(20))
 				H.emote(pick("giggle", "laugh"))
 

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,8 +5,10 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	if(stat == (DEAD || ANESTHETIZED))
+	if(stat == (DEAD | ANESTHETIZED))
 		return				//No messages when Anesthetized or Dead
+	if(status_flags & FAKEDEATH)
+		return				//No messages when Fake Dead.
 	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
 		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(reagents.has_reagent("sal_acid"))
@@ -33,8 +35,10 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	if(stat == (DEAD || ANESTHETIZED))
+	if(stat == (DEAD | ANESTHETIZED))
 		return				//No messages when Anesthetized or Dead
+	if(status_flags & FAKEDEATH)
+		return				//No messages when Fake Dead.
 	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
 		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(NO_PAIN in dna.species.species_traits)
@@ -54,7 +58,9 @@
 
 /mob/living/carbon/human/proc/handle_pain()
 	// not when Anesthetized or Dead
-	if(stat == DEAD || stat == ANESTHETIZED)
+	if(stat == (DEAD | ANESTHETIZED))
+		return
+	if(status_flags & FAKEDEATH)
 		return
 	if(NO_PAIN in dna.species.species_traits)
 		return

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,9 +5,10 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	// not when Anesthetized or Dead
-	if(stat == DEAD || stat == ANESTHETIZED)
-		return
+	if(stat == (DEAD || ANESTHETIZED))
+		return				//No messages when Anesthetized or Dead
+	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
+		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(reagents.has_reagent("sal_acid"))
 		return
 	if(reagents.has_reagent("morphine"))
@@ -32,9 +33,10 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	// not when Anesthetized or Dead
-	if(stat == DEAD || stat == ANESTHETIZED)
-		return
+	if(stat == (DEAD || ANESTHETIZED))
+		return				//No messages when Anesthetized or Dead
+	if(stat == UNCONSCIOUS)	//You can't sleep through the pain.
+		WakeUp()			//This is going to come back to bite us hard with antags.
 	if(NO_PAIN in dna.species.species_traits)
 		return
 	if(reagents.has_reagent("morphine"))

--- a/code/modules/surgery/organs/pain.dm
+++ b/code/modules/surgery/organs/pain.dm
@@ -5,7 +5,8 @@
 // partname is the name of a body part
 // amount is a num from 1 to 100
 /mob/living/carbon/human/proc/pain(partname, amount)
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
 	if(reagents.has_reagent("sal_acid"))
 		return
@@ -31,9 +32,9 @@
 
 // message is the custom message to be displayed
 /mob/living/carbon/human/proc/custom_pain(message)
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
-
 	if(NO_PAIN in dna.species.species_traits)
 		return
 	if(reagents.has_reagent("morphine"))
@@ -50,9 +51,8 @@
 	next_pain_time = world.time + 100
 
 /mob/living/carbon/human/proc/handle_pain()
-	// not when sleeping
-
-	if(stat >= UNCONSCIOUS)
+	// not when Anesthetized or Dead
+	if(stat == DEAD || stat == ANESTHETIZED)
 		return
 	if(NO_PAIN in dna.species.species_traits)
 		return

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -322,24 +322,25 @@
 		user.visible_message("[user] begins reattaching [target]'s [tool].", \
 		"You start reattaching [target]'s [tool].")
 		target.custom_pain("Someone's rooting around in your [affected.name]!")
+
 	else if(istype(tool,/obj/item/mmi))
 		current_type = "install"
-
 		if(target_zone != "chest")
 			to_chat(user, "<span class='notice'> You must target the chest cavity.</span>")
-
 			return -1
 		var/obj/item/mmi/M = tool
-
-
 		if(!affected)
 			return -1
-
 		if(!istype(M))
 			return -1
-
-		if(!M.brainmob || !M.brainmob.client || !M.brainmob.ckey || M.brainmob.stat == DEAD)
+		if(!M.brainmob || !M.brainmob.ckey)
 			to_chat(user, "<span class='danger'>That brain is not usable.</span>")
+			return -1
+		if(!M.brainmob.client)
+			to_chat(user, "<span class='danger'>That brain seems to be missing a mind.</span>")
+			return -1
+		if(!M.brainmob.stat == DEAD)
+			to_chat(user, "<span class='danger'>That brain appears lifeless and dead.</span>")
 			return -1
 
 		if(!affected.is_robotic())

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -338,7 +338,7 @@
 		if(!istype(M))
 			return -1
 
-		if(!M.brainmob || !M.brainmob.client || !M.brainmob.ckey || M.brainmob.stat >= DEAD)
+		if(!M.brainmob || !M.brainmob.client || !M.brainmob.ckey || M.brainmob.stat == DEAD)
 			to_chat(user, "<span class='danger'>That brain is not usable.</span>")
 			return -1
 


### PR DESCRIPTION
## What Does This PR Do

- This PR adds a new vitals stat called ANESTHETIZED which functions the same way as using the Sleep verb currently does for surgery.
- This PR makes it so you can no longer use the Sleep verb to get through surgery.
- This PR makes it so pain will always wake up mobs who are UNCONSCIOUS.
- Pain will not wake mobs who are ANESTHETIZED

## Why It's Good For The Game

- Mobs can no longer sleep through surgery.
- Surgery now requires either painkillers, ether, Anesthesia gas mixture, or N2O.

## What Causes a Mob to become Anesthetized?

- Going SSD (so you can still do surgery on SSD people as you currently can)
- Sleeping Agent (N2O)
- Anesthetic Tank (it's freakin' anesthesia)
- Abductor Baton
- Morphine (if taken in high enough dosage), but not Hydrocodone (that one is straight-up pain killer)
- Ketamine (this is what is in Sleepy Pens)
- Neurotoxin (drink)
- Neurotoxin (toxin)
- Capulettium (toxin), but not Capulettium Plus (that one is straight-up FAKEDEATH)
- Curare (toxin) (used in an Italian film where a cat is the murder weapon)
- Pancuronium (toxin)
- Sodium Thipental (toxin)
- Sulfonal (toxin)
- .50 Soporific Sniper Rifle Bullet (bullet)
- Ether

## Changelog

fix: Mobs can no longer Sleep through surgery or Sleep through pain
add: New stat: ANESTHETIZED