### PR TITLE
Sleep Less in Spacebattle

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -44,6 +44,7 @@
 	icon_state = "anesthetic"
 	item_state = "an_tank"
 	force = 10
+	shutoff = 360	// 6 minutes
 
 /obj/item/tank/internals/anesthetic/populate_gas()
 	air_contents.oxygen = (3 * ONE_ATMOSPHERE) * volume / (R_IDEAL_GAS_EQUATION * T20C) * O2STANDARD

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -16,6 +16,8 @@
 	var/distribute_pressure = ONE_ATMOSPHERE
 	var/integrity = 3
 	var/volume = 70
+	var/tanktimer = null
+	var/shutoff = 0	// Measured in Seconds
 
 /obj/item/tank/New()
 	..()
@@ -49,6 +51,9 @@
 
 	if(C.internal == src)
 		to_chat(C, "<span class='notice'>You close \the [src] valve.</span>")
+		if(shutoff)
+			deltimer(tanktimer)
+			tanktimer = null
 		C.internal = null
 	else
 		if(!C.get_organ_slot("breathing_tube")) // Breathing tubes can always use internals, if they have one, skip ahead and turn internals on/off
@@ -70,8 +75,20 @@
 			else
 				to_chat(C, "<span class='notice'>You open \the [src] valve.</span>")
 		C.internal = src
+		if(shutoff)
+			tanktimer = addtimer(CALLBACK(src, /obj/item/tank/.proc/turnoff_callback, C), shutoff SECONDS, TIMER_STOPPABLE)
 	C.update_action_buttons_icon()
 
+/obj/item/tank/proc/turnoff_callback(mob/user)
+	var/mob/living/carbon/C = user
+	if(istype(C))
+		var/min = round((shutoff/60), 0.5)
+		if(min > 1)
+			visible_message("</span class='notice'>\The [src] shuts off automatically after [min] minutes.</span>")
+		else
+			visible_message("</span class='notice'>\The [src] shuts off automatically after a minute.</span>")
+		C.internal = null
+		C.update_action_buttons_icon()
 
 /obj/item/tank/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

- Resolves this: "_I also feel that anesthetic tanks should have a timer attached to automatically turn off the gas if the patent is unconscious for too long, so that they aren't asleep forever._" - **Tipsy**
- Adds an automatic `shutoff` timer to all tanks:
  - When set to 0 (default value), it does not set a timer
  - This is set to 360 for Anesthesia tanks (6 minutes)

<!-- Include a small to medium description of what your PR changes. Document every changes or this may delay review or even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Now you won't have to AHELP when your doctor gets eaten by a Terror Spooder.
- Or _becomes_ a Terror Spooder, Pax. _Pax_. ***PAX!!***

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes
![image](https://user-images.githubusercontent.com/69871346/113783386-ab526f80-9701-11eb-919a-2ac11d55c2b7.png)
Okay, look, I set it to 30 seconds for testing and I wasn't going to share a 30 second video of me being asleep ;--;
<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif of your feature if you want -->

## Changelog
:cl:
add: Automatic shut-off timer (6 minutes) for Anesthesia internals tank
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
